### PR TITLE
Scrub dictionary contents before splitting to avoid runtime error "Ar…

### DIFF
--- a/lib/ruby-dictionary/dictionary.rb
+++ b/lib/ruby-dictionary/dictionary.rb
@@ -68,7 +68,7 @@ class Dictionary
       contents = gz.read
     end
 
-    new(contents.split(separator), case_sensitive)
+    new(contents.scrub.split(separator), case_sensitive)
   end
 
   private


### PR DESCRIPTION
…gumentError: invalid byte sequence in UTF-8" when file containing invalid character(s) is read in
